### PR TITLE
VYV-2196 Localized speakers

### DIFF
--- a/Beey.DataExchangeModel.Common/Beey.DataExchangeModel.Common.csproj
+++ b/Beey.DataExchangeModel.Common/Beey.DataExchangeModel.Common.csproj
@@ -1,11 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\objectgraphvalidation\ObjectGraphValidation.csproj" />
     <ProjectReference Include="..\TranscriptionCore\TranscriptionCore.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Beey.DataExchangeModel.Common/Speakers/CommonSpeakerFields.cs
+++ b/Beey.DataExchangeModel.Common/Speakers/CommonSpeakerFields.cs
@@ -2,24 +2,30 @@
 
 public static class CommonSpeakerFields
 {
-    public static SpeakerStringField FirstName { get; } = new("firstName");
+    public static SpeakerLocalizedStringField FirstName { get; } = new("firstName");
 
-    public static SpeakerStringField MiddleName { get; } = new("middleName");
+    public static SpeakerLocalizedStringField MiddleName { get; } = new("middleName");
 
-    public static SpeakerStringField LastName { get; } = new("lastName");
+    public static SpeakerLocalizedStringField LastName { get; } = new("lastName");
 
-    public static SpeakerStringField DegreeBefore { get; } = new("degreeBefore");
+    public static SpeakerLocalizedStringField DegreeBefore { get; } = new("degreeBefore");
 
-    public static SpeakerStringField DegreeAfter { get; } = new("degreeAfter");
+    public static SpeakerLocalizedStringField DegreeAfter { get; } = new("degreeAfter");
 
     public static SpeakerStringField ImageBase64 { get; } = new("imageBase64");
 
     public static SpeakerStringField DefaultIsoLang { get; } = new("defaultIsoLang");
 
-    public static SpeakerStringField Role { get; } = new("role");
+    public static SpeakerLocalizedStringField Role { get; } = new("role");
 }
 
 public readonly record struct SpeakerStringField(string FieldName)
+{
+    public override string ToString() => this.FieldName;
+}
+
+
+public readonly record struct SpeakerLocalizedStringField(string FieldName)
 {
     public override string ToString() => this.FieldName;
 }

--- a/Beey.DataExchangeModel.Common/Speakers/CommonSpeakerFields.cs
+++ b/Beey.DataExchangeModel.Common/Speakers/CommonSpeakerFields.cs
@@ -2,30 +2,43 @@
 
 public static class CommonSpeakerFields
 {
-    public static SpeakerLocalizedStringField FirstName { get; } = new("firstName");
+    public static SpeakerLocalizedStringField FirstName { get; } = new("firstName", TextReadOptions());
 
-    public static SpeakerLocalizedStringField MiddleName { get; } = new("middleName");
+    public static SpeakerLocalizedStringField MiddleName { get; } = new("middleName", TextReadOptions());
 
-    public static SpeakerLocalizedStringField LastName { get; } = new("lastName");
+    public static SpeakerLocalizedStringField LastName { get; } = new("lastName", TextReadOptions());
 
-    public static SpeakerLocalizedStringField DegreeBefore { get; } = new("degreeBefore");
+    public static SpeakerLocalizedStringField DegreeBefore { get; } = new("degreeBefore", TextReadOptions());
 
-    public static SpeakerLocalizedStringField DegreeAfter { get; } = new("degreeAfter");
+    public static SpeakerLocalizedStringField DegreeAfter { get; } = new("degreeAfter", TextReadOptions());
 
-    public static SpeakerStringField ImageBase64 { get; } = new("imageBase64");
+    public static SpeakerStringField ImageBase64 { get; } = new("imageBase64", TextReadOptions());
 
-    public static SpeakerStringField DefaultIsoLang { get; } = new("defaultIsoLang");
+    public static SpeakerStringField DefaultIsoLang { get; } = new("defaultIsoLang", TextReadOptions());
 
-    public static SpeakerLocalizedStringField Role { get; } = new("role");
+    public static SpeakerLocalizedStringField Role { get; } = new("role", TextReadOptions());
+
+    static SpeakerDataStringReadOptions TextReadOptions() => new()
+    {
+        ReadNumberAsString = false,
+        ReadValuesFromObjects = false,
+        StringJoinCharacter = " "
+    };
 }
 
-public readonly record struct SpeakerStringField(string FieldName)
+public class SpeakerStringField(string fieldName, SpeakerDataStringReadOptions? options) : SpeakerFieldBase(fieldName)
 {
-    public override string ToString() => this.FieldName;
+    public SpeakerDataStringReadOptions? StringReadOptions { get; } = options;
 }
 
-
-public readonly record struct SpeakerLocalizedStringField(string FieldName)
+public class SpeakerLocalizedStringField(string fieldName, SpeakerDataStringReadOptions? options) : SpeakerFieldBase(fieldName)
 {
-    public override string ToString() => this.FieldName;
+    public SpeakerDataStringReadOptions? StringReadOptions { get; } = options;
+}
+
+public class SpeakerFieldBase(string fieldName)
+{
+    public string FieldName { get; } = fieldName;
+
+    public override string ToString() => FieldName;
 }

--- a/Beey.DataExchangeModel.Common/Speakers/SpeakerDtoExtensions.cs
+++ b/Beey.DataExchangeModel.Common/Speakers/SpeakerDtoExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.Json.Nodes;
+﻿using System.Globalization;
+using System.Text.Json.Nodes;
 using Beey.DataExchangeModel.Common.Speakers.v1;
+using Beey.DataExchangeModel.Common.Tools;
 
 namespace Beey.DataExchangeModel.Common.Speakers;
 public static class SpeakerDtoExtensions
@@ -13,6 +15,95 @@ public static class SpeakerDtoExtensions
 
     public static void Set(this SpeakerDto dto, SpeakerStringField field, string? newValue)
     {
+        if (newValue == null)
+            dto.Data.Json.Remove(field.FieldName);
+        else
+            dto.Data.Json[field.FieldName] = JsonValue.Create(newValue);
+    }
+
+    public static string? Get(this SpeakerDto dto, SpeakerLocalizedStringField field, CultureInfo? ci)
+    {
+        if (!dto.Data.Json.TryGetPropertyValue(field.FieldName, out var propertyNode))
+            return null; // not found at all
+
+        if (TryReadAsText(propertyNode, out var result))
+            return result;
+
+        if (propertyNode is not JsonObject localizations)
+            return null; // unexpected type
+
+        string? candidate = null;
+
+        // 1 = at least something
+        // 2 = neutral match
+        // 3 = weak match (only by language, not by country/culture)
+        var candidateQuality = 0;
+
+        foreach (var kv in localizations)
+        {
+            if (kv.Key == "*")
+            {
+                if (ci is null && TryReadAsText(kv.Value, out result))
+                {
+                    // this is an exact match if we look for neutral version
+                    return result;
+                }
+
+                if (candidateQuality < 2 && TryReadAsText(kv.Value, out result))
+                {
+                    // neutral version is the best candidate so far
+                    candidate = result;
+                    candidateQuality = 2;
+                    continue;
+                }
+            }
+
+            if (ci is not null && LanguageHelper.TryParseLanguage(kv.Key, out var locLang))
+            {
+                if (locLang.LCID == ci.LCID && TryReadAsText(kv.Value, out result))
+                {
+                    // exact match
+                    return result;
+                }
+
+                if (candidateQuality < 3 && ci.TwoLetterISOLanguageName == locLang.TwoLetterISOLanguageName &&
+                    TryReadAsText(kv.Value, out result))
+                {
+                    // weak match
+                    candidateQuality = 3;
+                    candidate = result;
+                    continue;
+                }
+            }
+
+            if (candidateQuality < 1 && TryReadAsText(kv.Value, out result))
+            {
+                candidate = result;
+                candidateQuality = 1;
+            }
+        }
+
+        // this is the best we have
+        return candidate;
+    }
+
+    static bool TryReadAsText(JsonNode? itemNode, out string result)
+    {
+        if (itemNode is JsonValue textNode &&
+            textNode.TryGetValue<string>(out var text))
+        {
+            result = text;
+            return true;
+        }
+
+        result = null!;
+        return false;
+    }
+
+    public static void Set(this SpeakerDto dto, SpeakerLocalizedStringField field, string? newValue, CultureInfo? ci)
+    {
+        // TODO: Update only the specific language version
+
         if (newValue == null)
             dto.Data.Json.Remove(field.FieldName);
         else

--- a/Beey.DataExchangeModel.Common/Speakers/SpeakerJsonReader.cs
+++ b/Beey.DataExchangeModel.Common/Speakers/SpeakerJsonReader.cs
@@ -1,0 +1,209 @@
+﻿using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Beey.DataExchangeModel.Common.Speakers;
+
+/// <summary>Reads various data-type values from speaker JSON nodes</summary>
+public static class SpeakerJsonReader
+{
+    public static string? GetString(JsonNode node, SpeakerDataStringReadOptions? options)
+    {
+        StringCollector collector = new(options);
+        CollectValues(node, ref collector, options, StringCollector.TryCollectString);
+        return collector.Result;
+    }
+
+    public static IReadOnlyList<string>? GetStringArray(JsonNode node, SpeakerDataStringReadOptions? options)
+    {
+        StringArrayCollector collector = new(options);
+        CollectValues(node, ref collector, options, StringArrayCollector.TryCollectString);
+        return collector.Result;
+    }
+
+    static bool TryReadSingleString(JsonNode? node, SpeakerDataStringReadOptions? options, out string value)
+    {
+        switch (node?.GetValueKind())
+        {
+            case JsonValueKind.String:
+                value = node.ToString();
+                return true;
+
+            case JsonValueKind.Number when options?.ReadNumberAsString ?? SpeakerDataStringReadOptions.DefaultReadNumberAsString:
+                value = node.ToString();
+                return true;
+        }
+        value = default!;
+        return false;
+    }
+
+    struct StringCollector(SpeakerDataStringReadOptions? options)
+    {
+        // This is a highly optimized collector for single string value,
+        // focused to do minimum memory allocations
+
+        readonly SpeakerDataStringReadOptions? _options = options;
+
+        public string? Result => _collected switch
+        {
+            string singleValue => singleValue,
+            StringBuilder buff => buff.ToString(),
+            _ => null
+        };
+
+        // one of (null || string || StringBuilder)
+        object? _collected;
+
+        public static bool TryCollectString(JsonNode? node, ref StringCollector collector)
+        {
+            if (!TryReadSingleString(node, collector._options, out var newString))
+                return false;
+
+            if (collector._collected is null)
+            {
+                // most usual case
+                collector._collected = newString;
+                return true;
+            }
+
+            var joinCharacter = collector._options is null
+                ? SpeakerDataStringReadOptions.DefaultStringJoinCharacter
+                : collector._options.StringJoinCharacter;
+
+            if (joinCharacter is null)
+                return true; // only previous value is used, skip this one
+
+            StringBuilder buff;
+            if (collector._collected is string prevValue)
+            {
+                buff = new StringBuilder(prevValue);
+                collector._collected = buff;
+            }
+            else
+            {
+                buff = (StringBuilder)collector._collected;
+            }
+            buff.Append(joinCharacter);
+            buff.Append(newString);
+            return true;
+        }
+    }
+
+    struct StringArrayCollector(SpeakerDataStringReadOptions? options)
+    {
+        readonly SpeakerDataStringReadOptions? _options = options;
+
+        // one of (null || string || string[] || List<string>)
+        object? _collected;
+
+        public IReadOnlyList<string>? Result => _collected switch
+        {
+            string singleValue => [singleValue],
+            string[] array => array,
+            List<string> list => list,
+            _ => null
+        };
+
+        public static bool TryCollectString(JsonNode? node, ref StringArrayCollector collector)
+        {
+            if (TryReadSingleString(node, collector._options, out var newString))
+            {
+                collector.AddSingleValue(newString);
+                return true;
+            }
+
+            if (node is JsonArray array && collector._collected is null)
+                return collector.TryLoadStringArray(array);
+
+            return false;
+        }
+
+        void AddSingleValue(string value)
+        {
+            switch (_collected)
+            {
+                case null:
+                    _collected = value;
+                    return;
+
+                case string prevValue:
+                    // we are optimistic that there won't be more items
+                    _collected = new[] { prevValue, value };
+                    return;
+
+                case string[] prevArray:
+                    // presumably there are 2 items in the array
+                    // make some more space (8 items) to avoid soon re-allocations
+                    var newList = new List<string>(prevArray.Length + 6);
+                    newList.AddRange(prevArray);
+                    newList.Add(value);
+                    _collected = newList;
+                    return;
+
+                case List<string> prevList:
+                    prevList.Add(value);
+                    return;
+            }
+        }
+
+        bool TryLoadStringArray(JsonArray jsonArray)
+        {
+            // this is optimisation for case that json array is all strings
+            // we postpone allocation after we check out the first item
+            string[]? items = null;
+            for (var i = 0; i < jsonArray.Count; i++)
+            {
+                if (!TryReadSingleString(jsonArray[i], _options, out var nextString))
+                    return false; // fallback to non-optimized processing instead
+
+                items ??= new string[jsonArray.Count];
+                items[i] = nextString;
+            }
+
+            // we are happy now
+            _collected = items ?? []; // make sure we have at least empty array to clarify that property was found
+            return true;
+        }
+    }
+
+    static void CollectValues<TCollector>(JsonNode? node, ref TCollector collector, SpeakerDataStringReadOptions? options, TryCollectValue<TCollector> tryCollectValue)
+    {
+        if (tryCollectValue(node, ref collector))
+            return;
+
+        switch (node?.GetValueKind())
+        {
+            case JsonValueKind.Array:
+                foreach (var jsonItem in node.AsArray())
+                {
+                    CollectValues(jsonItem, ref collector, options, tryCollectValue);
+                }
+                return;
+
+            case JsonValueKind.Object when options?.ReadValuesFromObjects ?? SpeakerDataStringReadOptions.DefaultReadValuesFromObjects:
+                foreach (var kv in node.AsObject())
+                {
+                    CollectValues(kv.Value, ref collector, options, tryCollectValue);
+                }
+                return;
+        }
+    }
+
+    delegate bool TryCollectValue<TCollector>(JsonNode? node, ref TCollector collector);
+}
+
+public class SpeakerDataStringReadOptions
+{
+    public const bool DefaultReadNumberAsString = false;
+    public const bool DefaultReadValuesFromObjects = false;
+    public const string DefaultStringJoinCharacter = " ";
+
+    /// <summary>If true, JSON numbers are read as strings as well, otherwise they are ignored</summary>
+    public bool ReadNumberAsString { get; set; } = DefaultReadNumberAsString;
+
+    /// <summary>If true, JSON objects are enumerated while reading and values are processed recursively; otherwise JSON objects are ignored</summary>
+    public bool ReadValuesFromObjects { get; set; } = DefaultReadValuesFromObjects;
+
+    /// <summary>Character used when multiple strings are joined into one; if null then only first value is used</summary>
+    public string? StringJoinCharacter { get; set; } = DefaultStringJoinCharacter;
+}

--- a/Beey.DataExchangeModel.Common/Speakers/SpeakerJsonReader.cs
+++ b/Beey.DataExchangeModel.Common/Speakers/SpeakerJsonReader.cs
@@ -8,9 +8,15 @@ namespace Beey.DataExchangeModel.Common.Speakers;
 public static class SpeakerJsonReader
 {
     public static string? GetString(JsonNode node, SpeakerDataStringReadOptions? options)
+        => GetString([node], options);
+
+    public static string? GetString(IEnumerable<JsonNode> nodes, SpeakerDataStringReadOptions? options)
     {
         StringCollector collector = new(options);
-        CollectValues(node, ref collector, options, StringCollector.TryCollectString);
+        foreach (var node in nodes)
+        {
+            CollectValues(node, ref collector, options, StringCollector.TryCollectString);
+        }
         return collector.Result;
     }
 

--- a/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerCatalogRequests.cs
+++ b/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerCatalogRequests.cs
@@ -25,6 +25,9 @@ public class SpeakerCatalogRequestSuggest
     public int? Count { get; set; }
 
     public SpeakerCatalogScope? Scope { get; set; }
+
+    /// <summary>IETF language tag (BCP 47, former RFC-4646)</summary>
+    public string? Language { get; set; }
 }
 
 public class SpeakerCatalogRequestGet

--- a/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerDto.JSON.md
+++ b/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerDto.JSON.md
@@ -1,0 +1,86 @@
+﻿
+# Speaker JSON structure v1
+
+A complete example:
+
+```json
+{
+    "firstName": "Vladimir",
+    "lastName": {
+        "*": "Zelenskyy",
+        "cs": "Zelenský" },
+    "defaultIsoLang": "uk-UA",
+    "role": {
+        "uk-UA": "Президент",
+        "cs-CZ": "ukrajinský prezident"
+    },
+    "custom": [
+    {
+        "name": "a",
+        "value": "something",
+        "date": "2024-09-11T17:55:19.1126113+00:00" }
+    ],
+    "beey_custom_tag": "UK-flag"
+}
+```
+
+This example shows multiple possible ways to express localized texts, languages etc.
+
+The JSON structure is opened and you can find anything in the JSON data. All fields are optinal and you can even find fields to have different data types.
+
+If you update the speaker you should always keep the other fields intact.
+
+This document is a recommendation for best compatibility rather than a specification.
+
+| Field | JSON type | Meaning | Example(s) | C# constant for the key |
+|---|---|---|---|
+| `"firstName"` | [localized text](#localized-texts) | First name | `"Vladimir"`, `{"cz-CZ": "Vladimír"}`, ... | `CommonSpeakerFields.FirstName` |
+| `"middleName"` | [localized text](#localized-texts) | Middle name | `null`, `{}`, ... | `CommonSpeakerFields.MiddleName` |
+| `"lastName"` | [localized text](#localized-texts) | Last name | `"Bind"`, `{"cz-CZ": ""}` | `CommonSpeakerFields.LastName` |
+| `"degreeBefore"` | [localized text](#localized-texts) | Degree before | | `CommonSpeakerFields.DegreeBefore` |
+| `"degreeAfter"` | [localized text](#localized-texts) | Degree after | | `CommonSpeakerFields.DegreeAfter` |
+| `"imageBase64"` | text (base-64 encoded JPEG) | Thumbnail encoded in base64 | | `CommonSpeakerFields.ImageBase64` |
+| `"defaultIsoLang"` | text ([language](#languages)) | Native language of the speaker | `"cs-CZ"` | `CommonSpeakerFields.DefaultIsoLang` |
+| `"role"` | [localized text](#localized-texts) | Usual role of the person | `"secret agent"`, ... | `CommonSpeakerFields.Role` |
+| `"custom"` | array of [custom attributes](#custom-attributes) | Attributes from/to TRSX | `[{"key": .., ..}]` | `CommonSpeakerFields.role` |
+| any other fiels | any | There is no limit to which fields can be here | | |
+
+# Localized texts
+
+A localized text can be expressed as either:
+1. _JSON text_, or
+2. _JSON object_ with different texts for language
+
+In the first case, the single text is used for all languages.
+
+In the second case, the object has keys according to available [languages](#languages), or `"*"` for language-agnostic value.
+
+| Field | JSON type | Example | Meaning |
+|---|---|---|---|
+| `"*"` | text | `"Zelenskyy"` | optional default (language-agnostic) version of the value |
+| `"cs"` | text | `"Zelenský"` | optional Czech translation |
+| `"de-DE"` | text | `"Selenskyj"` | optional German translation |
+| other | text | `...` | any unexpected translations may be also present |
+
+If you need specific version for your language and it's not there, you should use the `"*"` version. If that version is not found either, you should use the first version in the list.
+
+# Custom attributes
+
+The custom attributes are here only for compatibility with TRSX attributes. Each of then can have these fields (all optional):
+
+| Field | JSON type | C# mapping |
+|---|---|---|
+| `"name"` | text | `SpeakerAttribute.Name` |
+| `"id"` | text | `SpeakerAttribute.ID` |
+| `"value"` | text | `SpeakerAttribute.Value` |
+| `"date"` | text (ISO 8601-1:2019 date/time) | `SpeakerAttribute.Date` |
+
+# Languages
+
+Language codes are based on IETF language tag (RFC-4646). Usually the tag can have one of two forms:
+* `"cs"` – just the language code
+* `"cs-CZ"` – includes also country/region code
+
+Both forms are possible. The two-letter language code is defined by to ISO 639 while ISO 3166 defines country/region codes.
+
+The language code is case-sensitive. Any unknown language code should be accepted as well (just process it as an unknown language).

--- a/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerDto.JSON.md
+++ b/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerDto.JSON.md
@@ -33,7 +33,7 @@ If you update the speaker you should always keep the other fields intact.
 This document is a recommendation for best compatibility rather than a specification.
 
 | Field | JSON type | Meaning | Example(s) | C# constant for the key |
-|---|---|---|---|
+|---|---|---|---|---|
 | `"firstName"` | [localized text](#localized-texts) | First name | `"Vladimir"`, `{"cz-CZ": "Vladimír"}`, ... | `CommonSpeakerFields.FirstName` |
 | `"middleName"` | [localized text](#localized-texts) | Middle name | `null`, `{}`, ... | `CommonSpeakerFields.MiddleName` |
 | `"lastName"` | [localized text](#localized-texts) | Last name | `"Bind"`, `{"cz-CZ": ""}` | `CommonSpeakerFields.LastName` |

--- a/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerDto.JSON.md
+++ b/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerDto.JSON.md
@@ -1,81 +1,55 @@
 ﻿
-# Speaker JSON structure v1
+# Generic speaker JSON structure v1
 
-A complete example:
+An example:
 
 ```json
 {
-    "firstName": "Vladimir",
-    "lastName": {
-        "*": "Zelenskyy",
-        "cs": "Zelenský" },
-    "defaultIsoLang": "uk-UA",
-    "role": {
-        "uk-UA": "Президент",
-        "cs-CZ": "ukrajinský prezident"
+  "UniqueId": null,
+  "Data": {
+    "Neutral": {
+      "firstName": "Wall-E"
     },
-    "custom": [
-    {
-        "name": "a",
-        "value": "something",
-        "date": "2024-09-11T17:55:19.1126113+00:00" }
-    ],
-    "beey_custom_tag": "UK-flag"
+    "Localizations": {
+      "cs-CZ": {
+        "firstName": "WALL-I"
+      }
+    },
+    "Schema": 1
+  },
+  "ConcurrencyToken": null
 }
 ```
 
-This example shows multiple possible ways to express localized texts, languages etc.
+The actual data are in these nodes:
+
+| Field | Meaning |
+|---|---|
+| `"Neutral"` | Contains language-neutral data of the speaker |
+| `"Localizations"` | Contains language-specific data of the speaker |
+
+Language-specific data are stored as a dictionary where key is a [language tag](#language-tag).
 
 Follow these rules for working with the format:
 * Expect anything and always do the best effort to interpret the values the best way you can.
-* If you can't localized text for your language, implement fallback to other language or neutral variant.
+* If you can't find localized text for your language, implement fallback to other language or neutral variant (see below).
 * The actual format can be always different from the specification. Don't throw exceptions, just read all the fields you can instead.
 * Preserve as much original data as possible when updating the structure.
 
-| Field | JSON type | Meaning | Example(s) | C# constant for the key |
-|---|---|---|---|---|
-| `"firstName"` | [localized text](#localized-texts) | First name | `"Vladimir"`, `{"cz-CZ": "Vladimír"}`, ... | `CommonSpeakerFields.FirstName` |
-| `"middleName"` | [localized text](#localized-texts) | Middle name | `null`, `{}`, ... | `CommonSpeakerFields.MiddleName` |
-| `"lastName"` | [localized text](#localized-texts) | Last name | `"Bind"`, `{"cz-CZ": ""}` | `CommonSpeakerFields.LastName` |
-| `"degreeBefore"` | [localized text](#localized-texts) | Degree before | | `CommonSpeakerFields.DegreeBefore` |
-| `"degreeAfter"` | [localized text](#localized-texts) | Degree after | | `CommonSpeakerFields.DegreeAfter` |
-| `"imageBase64"` | text (base-64 encoded JPEG) | Thumbnail encoded in base64 | | `CommonSpeakerFields.ImageBase64` |
-| `"defaultIsoLang"` | text ([language](#languages)) | Native language of the speaker | `"cs-CZ"` | `CommonSpeakerFields.DefaultIsoLang` |
-| `"role"` | [localized text](#localized-texts) | Usual role of the person | `"secret agent"`, ... | `CommonSpeakerFields.Role` |
-| `"custom"` | array of [custom attributes](#custom-attributes) | Attributes from/to TRSX | `[{"key": .., ..}]` | `CommonSpeakerFields.role` |
-| any other fiels | any | There is no limit to which fields can be here | | |
+# Reading a localized field
 
-# Localized texts
+Always check various nodes when searching for the value. Some value is always better than no value.
 
-A localized text can be expressed as either:
-1. _JSON text_, or
-2. _JSON object_ with different texts for language
+If you are reading in language-agnostic context, your priority order should go like this:
+1. `Neutral` node
+2. `Localizations` subnodes in no particular order
 
-In the first case, the single text is used for all languages.
+If you are reading value for specific language, your priority order should differ:
+1. `Localizations` subnode exactly for your language (note that key is case-insensitive and `cs-CZ` equals `cs-cz`)
+2. `Localizations` subnode with "similar" language (with the same language code, for example `cs-CZ` is similar to `CS`)
+3. `Neutral` node
 
-In the second case, the object has keys according to available [languages](#languages), or `"*"` for language-agnostic value.
-
-| Field | JSON type | Example | Meaning |
-|---|---|---|---|
-| `"*"` | text | `"Zelenskyy"` | optional neutral version of the value |
-| `"cs"` | text | `"Zelenský"` | optional Czech translation |
-| `"de-DE"` | text | `"Selenskyj"` | optional German translation |
-| other | text | `...` | any unexpected translations may be also present |
-
-If you need specific version for your language and it's not there, you should use the neutral versio, or first version in the list.
-
-# Custom attributes
-
-The custom attributes are here only for compatibility with TRSX attributes. Each of then can have these fields (all optional):
-
-| Field | JSON type | C# mapping |
-|---|---|---|
-| `"name"` | text | `SpeakerAttribute.Name` |
-| `"id"` | text | `SpeakerAttribute.ID` |
-| `"value"` | text | `SpeakerAttribute.Value` |
-| `"date"` | text (ISO 8601-1:2019 date/time) | `SpeakerAttribute.Date` |
-
-# Languages
+# Language tag
 
 Language codes are based on IETF language tag (BCP 47, former RFC-4646). Usually the tag can have one of two forms:
 * `"cs"` – just the language code (ISO 639)
@@ -85,19 +59,3 @@ Both forms are possible. The language code is case-insensitive. Any unknown lang
 
 All these variants have the same meaning: `"cs-CZ"`, `"CS-CZ"`, `"cs-cz"`, `"cs"`, `"CS"` (just like in [.NET](https://sharplab.io/#v2:EYLgtghglgdgNAFxAJwK7wCYgNQB8ACADAAT4CMAdAOIA2A9sBDVAF4QJR0wDcAsAFD4ATGQECAKgFMAzggAUAIgDG0gLQBhAFoKAlH35TZi9QGUN2vRJnzlapS137DNlY6tGFpt/wH4ALMTOcuQkNDrEALwAfKRkAJxy6qg0CKjIkgCSMABmdBTq6eySJgAOkkpQ2VBKSSlpknJhFAAy6hkAInpAA==)). When you have doubts, you can try [BCP 47 validator](https://schneegans.de/lv/).
 
-# Reading localized texts
-
-This procedure considers one parameter: optional requested language.
-
-* If direct text value is stored then it is the result no matter what language was requested
-* If field is stored as localized (JSON object), then:
-  * If a language was requested (not null), then:
-    * If there is an _exact match_ (see below) then the first exact value is the result
-    * If there is a _weak match_ (see below) then the first matching value is the result
-  * If there is a neutral value (key `"*"`) then it's value is the result
-  * If there is any value at all, the first value is the result
-* In any other case result is `null`
-
-_Exact match_ means that requested language and stored localized variant have the same language code AND country/culture code. Comparison is case-insensitive.
-
-_Weak match_ means that requested language and stored localized variant have only the same language code. Comparison is case-insensitive.

--- a/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerDto.cs
+++ b/Beey.DataExchangeModel.Common/Speakers/v1/SpeakerDto.cs
@@ -25,8 +25,12 @@ public class SpeakerDto
 
 public class SpeakerData
 {
-    /// <summary> Any JSON data associated with the speaker </summary>
-    public JsonObject Json { get; set; } = new();
+    /// <summary> Language-neutral information about the speaker </summary>
+    public JsonObject Neutral { get; set; } = [];
+
+    /// <summary> Language-specific JSON data for various languages </summary>
+    /// <remarks> Key is any valid IETF (BCP 47) language tag </remarks>
+    public Dictionary<string, JsonObject> Localizations { get; set; } = [];
 
     /// <summary> Version of JSON data schema </summary>
     /// <remarks> This can be used in case of breaking changes of the schema in the future. </remarks>

--- a/Beey.DataExchangeModel.Common/Tools/LanguageHelper.cs
+++ b/Beey.DataExchangeModel.Common/Tools/LanguageHelper.cs
@@ -26,4 +26,7 @@ public static class LanguageHelper
         ci = value!;
         return value is not null;
     }
+
+    public static bool IsInvariant(this CultureInfo? ci)
+        => ci is null || ci.TwoLetterISOLanguageName == "iv"; // TODO: or is there any better solution?
 }

--- a/Beey.DataExchangeModel.Common/Tools/LanguageHelper.cs
+++ b/Beey.DataExchangeModel.Common/Tools/LanguageHelper.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Concurrent;
+using System.Globalization;
+
+namespace Beey.DataExchangeModel.Common.Tools;
+
+public static class LanguageHelper
+{
+    static readonly ConcurrentDictionary<string, CultureInfo?> s_languageCache = [];
+
+    public static bool TryParseLanguage(string ietfTag, out CultureInfo ci)
+    {
+        var value = s_languageCache.GetOrAdd(ietfTag, s =>
+        {
+            try
+            {
+                return CultureInfo.GetCultureInfoByIetfLanguageTag(ietfTag);
+            }
+            catch
+            {
+                // If parsing fails, we still want to cache the value, because exceptions are slow,
+                // and we don't want to throw the exception again next time with the same input
+                return null;
+            }
+        });
+
+        ci = value!;
+        return value is not null;
+    }
+}


### PR DESCRIPTION
Pár sdílených věcí, aby mohly fungovat lokalizace speakerů.
Pomocné metody pro čtení a nastavení různých fieldů pro určitý jazyk Get() a Set(), tyto metody bude používat BE Beey pro mapování na language-specific třídu `Speaker`; víceméně je cílem, aby se tam jazyky nepřemnožovaly, takže `cs` beru jako totéž, co `cs-CZ` a je jedno, co je uloženo, pak to taky řeší různé prioritizace, když chci, aby se pokud možno vždycky něco přečetlo, i kdyby to bylo v jiném jazyce. Je podporována "neutrální" varianta jako default fallback.
Jinak logika není úplně jednoduchá, ale je pokryta unit testy v jiných projektech, takže by měla funguje dobře, tak spíš jestli tam není něco co bychom chtěli, aby fungovalo úplně jinak?